### PR TITLE
couldn't get the test to run without these changes.  With this update…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+node_modules
+.vscode

--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ the function `escapeHatch()` sending all the ether in the vault to `escapeDestin
 The `escapeHatchCaller` can be changed by the`owner` or the `escapeCaller` by calling:
 
     function changeEscapeCaller(address _newEscapeCaller)
+
+### Running Tests
+
+    In a terminal window, run `testrpc --deterministic` to start the testrpc network
+    In another terminal window, run `truffle test --network=development` to run the tests.

--- a/truffle.js
+++ b/truffle.js
@@ -3,12 +3,17 @@ require('babel-polyfill');
 
 module.exports = {
   networks: {
-    test: {
-      host: "localhost",
-	  gasPrice: 1,
-      gas: 0xfffffff,
+    // test: {
+    //   host: "localhost",
+	  // gasPrice: 1,
+    //   gas: 0xfffffff,
+    //   port: 8545,
+    //   network_id: "*" // Match any network id
+    // }
+    development: {
+      host: 'localhost',
       port: 8545,
-      network_id: "*" // Match any network id
+      network_id: '*'
     }
   }
 };


### PR DESCRIPTION
…, you can run `testrpc` in one console, and `truffle test --network=development` in another to run the tests.